### PR TITLE
Bugfix: on real DB contexts CountAsync does not end before ToListAsyn…

### DIFF
--- a/PaginationDemo/PaginationDemo/Extensions/DataPagerExtension.cs
+++ b/PaginationDemo/PaginationDemo/Extensions/DataPagerExtension.cs
@@ -24,12 +24,11 @@ namespace PaginationDemo.Extensions
             paged.CurrentPage = page;
             paged.PageSize = limit;
 
-            var totalItemsCountTask = query.CountAsync(cancellationToken);
+            paged.TotalItems = await query.CountAsync(cancellationToken);
 
             var startRow = (page - 1) * limit;
             paged.Items = await query.Skip(startRow).Take(limit).ToListAsync(cancellationToken);
 
-            paged.TotalItems = await totalItemsCountTask;
             paged.TotalPages = (int)Math.Ceiling(paged.TotalItems / (double)limit);
 
             return paged;


### PR DESCRIPTION
…c starts

which leads to InvalidOperationException

1. While on InMemoryDatabase CountAsync returns almost immediately, on real-world DBs
(like MSSQL, for example) PaginateAsync will continue executing and start next async
task (query...ToListAsync()). Both of them will enter one critical section, so EF core
will throw an exception InvalidOperationException

More information: https://docs.microsoft.com/en-us/ef/core/dbcontext-configuration/#avoiding-dbcontext-threading-issues

2. I realized that local variable totalItemsCountTask used only once in method,
so I skipped that